### PR TITLE
Enable traffic to DB backend sooner

### DIFF
--- a/docker-4_hosts_2LB/templates/docker1_LB/haproxy/haproxy.cfg
+++ b/docker-4_hosts_2LB/templates/docker1_LB/haproxy/haproxy.cfg
@@ -64,9 +64,9 @@ backend health_check_backend
             mode tcp
             option httpchk
 
-                    server 1.db PRIVATE_IP_5:3306 check port 3000 inter 2s rise 30000 fall 6 backup
+                    server 1.db PRIVATE_IP_5:3306 check port 3000 inter 2s rise 600 fall 6 backup
 
-                    server 2.db PRIVATE_IP_6:3306 check port 3000 inter 2s rise 30000 fall 6
+                    server 2.db PRIVATE_IP_6:3306 check port 3000 inter 2s rise 600 fall 6
 
 
 


### PR DESCRIPTION
The traffic should we enabled after 600 successful checks, which takes 1200 seconds. 
This time should be enough to replicate changes on backend, since this installation should host only single DB. 

PR closes https://github.com/QualityUnit/LiveAgent-Docker/issues/10.